### PR TITLE
Remove Internal Ticker | Simplify `presentation`

### DIFF
--- a/cmd/subcommands/acci-ping/acci-ping.go
+++ b/cmd/subcommands/acci-ping/acci-ping.go
@@ -27,7 +27,6 @@ type Config struct {
 	*application.SharedFlags
 	*tabflags.FlagSet
 
-	debugFps           *int
 	debuggingTermSize  *string
 	filePath           *string
 	followingOnStart   *bool
@@ -69,7 +68,6 @@ func GetFlags(info *application.BuildInfo) *Config {
 		debuggingTermSize: tf.String("debug-term-size", "", "switches the terminal to fixed mode and no iteractivity",
 			tabflags.AutoComplete{Choices: []string{"15x80", "20x85", "HxW"}}),
 		followingOnStart:   tf.Bool("follow", false, "if this flag is used the graph will be shown in following mode immediately"),
-		debugFps:           tf.Int("debug-fps", 240, "configures the internal tickrate for the graph re-paint look (in FPS)"),
 		logarithmicOnStart: tf.Bool("logarithmic", false, "if this flag is used the graph will be shown in logarithmic mode immediately"),
 	}
 	*ret.pingBufferingLimit = 10

--- a/cmd/subcommands/acci-ping/application.go
+++ b/cmd/subcommands/acci-ping/application.go
@@ -37,10 +37,8 @@ type Application struct {
 	g    *graph.Graph
 	term *terminal.Terminal
 
-	toUpdate *os.File
-	config   Config
-	// this doesn't need a mutex because we ensure that no two threads have access to the same byte index (I
-	// think this is fine when the slice doesn't grow).
+	toUpdate   *os.File
+	config     Config
 	drawBuffer *draw.Buffer
 
 	errorChannel      chan error
@@ -108,7 +106,7 @@ func (app *Application) Run(
 	defer close(guiControlChannel)
 	defer close(guiSpeedChange)
 	// Very high FPS is good for responsiveness in the UI (since it's locked) and re-drawing on a re-size.
-	graph, cleanup, terminalSizeUpdates, err := app.g.Run(ctx, cancelFunc, *app.config.debugFps, app.listeners(), app.fallbacks)
+	graph, cleanup, terminalSizeUpdates, err := app.g.Run(ctx, cancelFunc, app.listeners(), app.fallbacks)
 	termRecover := func() {
 		_ = app.term.ClearScreen(terminal.UpdateSize)
 		cleanup()

--- a/cmd/tab_completion/tabflags/tabflags.go
+++ b/cmd/tab_completion/tabflags/tabflags.go
@@ -81,6 +81,7 @@ func (f *FlagSet) GetAutoCompleteFor(flagName string) *AutoComplete {
 func (f *FlagSet) GetNames(includeDebug bool, toSkip []string) []string {
 	f.syncFlagSet()
 	keys := maps.Keys(f.nameToAc)
+	// Add the dash first so that we remove items matching [toSkip]
 	withDash := iterutils.Map(keys, func(n string) string {
 		return "-" + n
 	})

--- a/draw/draw.go
+++ b/draw/draw.go
@@ -23,9 +23,6 @@ type Buffer struct {
 }
 
 // TODO paint buffer should be application level and agnostic to the draw buffer itself.
-//
-// TODO this buffering has race conditions, data can be written to the paint buffer while it's being read for
-// painting. A full investigation is required to determine if this is actually a problem.
 func NewPaintBuffer() *Buffer {
 	return newBuffer(int(indexCount.Load()))
 }

--- a/graph/drawing.go
+++ b/graph/drawing.go
@@ -28,10 +28,9 @@ import (
 )
 
 type computeFrameConfig struct {
-	timeBetweenFrames time.Duration
-	followLatestSpan  bool
-	drawSpinner       bool
-	yAxisScale        YAxisScale
+	followLatestSpan bool
+	drawSpinner      bool
+	yAxisScale       YAxisScale
 }
 
 func (c computeFrameConfig) Match(cfg computeFrameConfig) bool {
@@ -40,14 +39,6 @@ func (c computeFrameConfig) Match(cfg computeFrameConfig) bool {
 }
 
 const drawingDebug = false
-
-func getTimeBetweenFrames(fps int, pingsPerMinute ping.PingsPerMinute) time.Duration {
-	if fps == 0 {
-		return ping.PingsPerMinuteToDuration(pingsPerMinute)
-	} else {
-		return time.Duration(1000/fps) * time.Millisecond
-	}
-}
 
 var noFrame = func(w io.Writer) error { return nil }
 

--- a/graph/export_test.go
+++ b/graph/export_test.go
@@ -24,7 +24,7 @@ func (g *Graph) ComputeFrame() string {
 	painter := g.computeFrame(computeFrameConfig{
 		followLatestSpan: false,
 		drawSpinner:      false,
-		yAxisScale:       g.presentation.YAxisScale,
+		yAxisScale:       g.presentation.Get().YAxisScale,
 	})
 	err := painter(&b)
 	check.NoErr(err, "While painting frame to string buffer")

--- a/graph/graphdata/graphdata.go
+++ b/graph/graphdata/graphdata.go
@@ -8,7 +8,6 @@ package graphdata
 
 import (
 	"fmt"
-	"io"
 	"sync"
 	"time"
 
@@ -65,12 +64,6 @@ func (gd *GraphData) Summary() string {
 	gd.Lock()
 	defer gd.Unlock()
 	return gd.data.Summary()
-}
-
-func (gd *GraphData) AsCompact(w io.Writer) error {
-	gd.m.Lock()
-	defer gd.m.Unlock()
-	return gd.data.AsCompact(w)
 }
 
 func (gd *GraphData) Lock() {


### PR DESCRIPTION
Removes the framerate ticker, I don't think this is necessary anymore. Cleans up some now removed flags related to this ticker.

Removes the mutex around `presentation` and switched to just an `atomic.Of`, since this component doesn't have wider concurrency context and simply just needed a way to not tear this primitive is much cleaner implementation.

Fixes some tab_completion tests.