### PR TITLE
Fix panic when `net.ipv4.ping_group_range` is disabled

### DIFF
--- a/ping/api.go
+++ b/ping/api.go
@@ -68,10 +68,10 @@ func (p *Ping) OneShot(url string) (time.Duration, error) {
 
 	// Create a listener for the IP we will use
 	closer, err := p.startListening(url)
-	defer closer()
 	if err != nil {
 		return 0, err
 	}
+	defer closer()
 
 	dnsTimeout, cancel := context.WithTimeoutCause(context.Background(), time.Second, pingTimeout{Duration: 100 * time.Millisecond})
 	defer cancel()


### PR DESCRIPTION
I had `net.ipv4.ping_group_range` and when I ran the unit tests with `SHOULD_TEST_NETWORK=1` it was panic'ing the tests with:

```
--- FAIL: TestOneShot_google_com (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x48af36]

goroutine 7 [running]:
testing.tRunner.func1.2({0x8fcb20, 0xc7b870})
        /usr/local/go/src/testing/testing.go:1974 +0x419
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1977 +0x67f
panic({0x8fcb20?, 0xc7b870?})
        /usr/local/go/src/runtime/panic.go:860 +0x13a
github.com/Lexer747/acci-ping/ping.(*Ping).OneShot(0xc0000c8840, {0x96a490, 0xe})
        /home/alexlewis/repos/acci-ping/ping/api.go:118 +0x8e7
github.com/Lexer747/acci-ping/ping_test.TestOneShot_google_com(0xc0001bc248)
        /home/alexlewis/repos/acci-ping/ping/api_test.go:25 +0x4f
testing.tRunner(0xc0001bc248, 0x9801f8)
        /usr/local/go/src/testing/testing.go:2036 +0x21d
created by testing.(*T).Run in goroutine 1
        /usr/local/go/src/testing/testing.go:2101 +0xb13
FAIL    github.com/Lexer747/acci-ping/ping      0.099s
```

On this PR it still doesn't pass (expected) but it no longer panics:

```
--- FAIL: TestOneShot_google_com (0.00s)
    api_test.go:26: assertion failed: error is not nil: couldn't listen caused by: couldn't listen for ping packets:
```