### PR TITLE
Fix panic when same durations occur early

### DIFF
--- a/graph/graph_file_test.go
+++ b/graph/graph_file_test.go
@@ -1,6 +1,6 @@
 // Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
 //
-// Copyright 2024-2025 Lexer747
+// Copyright 2024-2026 Lexer747
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
@@ -226,4 +226,23 @@ func produceFrame(
 	defer func() { stdin.WriteCtrlC(t) }()
 	output := th.MakeBuffer(size)
 	return th.EmulateTerminal(g.ComputeFrame(), output, size, terminalWrapping)
+}
+
+func TestEqualDurations(t *testing.T) {
+	t.Parallel()
+	d := data.NewData("example.com")
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Several good packets, all identical duration -> stats.Min == stats.Max
+	for i := range 20 {
+		d.AddPoint(ping.PingResults{
+			Data: ping.PingDataPoint{
+				Duration:  13 * time.Millisecond,
+				Timestamp: base.Add(time.Duration(i) * time.Second),
+			},
+		})
+	}
+	// test is simply not to panic:
+	size := terminal.Size{Height: 32, Width: 216}
+	_ = produceFrame(t, size, d, graph.Linear, th.TerminalWrapping(0))
+	_ = produceFrame(t, size, d, graph.Logarithmic, th.TerminalWrapping(0))
 }

--- a/graph/xAxis.go
+++ b/graph/xAxis.go
@@ -1,6 +1,6 @@
 // Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
 //
-// Copyright 2024-2025 Lexer747
+// Copyright 2024-2026 Lexer747
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
@@ -240,10 +240,10 @@ func getX(t time.Time, span *XAxisSpanInfo, y drawingYAxis, s terminal.Size) int
 	newMin := min(max(1, s.Width-1), span.endX)
 	newMax := max(y.labelSize, span.startX)
 	timestamp := span.timeSpan.End.Sub(t)
-	if span.pingStats.GoodCount+span.spanStats.PacketsDropped <= 1 {
-		// Edge case, when we have exactly one datum but the overall graph has more than one datum so we
-		// didn't short-circuit and need to draw this one point in an arbitrary point between the spans start
-		// and end.
+	if span.pingStats.GoodCount+span.spanStats.PacketsDropped <= 1 || span.timeSpan.Duration == 0 {
+		// Edge case, when we have exactly one datum (or multiple points sharing an identical timestamp, so
+		// the span duration is zero) but the overall graph has more than one datum so we didn't short-circuit
+		// and need to draw this point in an arbitrary point between the spans start and end.
 		return int(numeric.NormalizeToRange(0.5, 0, 1, float64(newMin), float64(newMax)))
 	}
 	// These are inverted deliberately since the drawing reference is symmetric in the x

--- a/graph/yAxis.go
+++ b/graph/yAxis.go
@@ -1,6 +1,6 @@
 // Use of this source code is governed by a GPL-2 license that can be found in the LICENSE file.
 //
-// Copyright 2024-2025 Lexer747
+// Copyright 2024-2026 Lexer747
 //
 // SPDX-License-Identifier: GPL-2.0-only
 
@@ -88,13 +88,14 @@ func computeYAxis(
 		h := i + 2
 		fmt.Fprint(toWriteTo, ansi.CursorPosition(h, 1))
 		if i%gapSize == 1 {
+			minY, maxY := effectiveYBounds(stats)
 			var scaledDuration float64
 			switch scale {
 			case Linear:
-				scaledDuration = numeric.NormalizeToRange(float64(i+1), float64(size.Height-3), 2, float64(stats.Min), float64(stats.Max))
+				scaledDuration = numeric.NormalizeToRange(float64(i+1), float64(size.Height-3), 2, float64(minY), float64(maxY))
 			case Logarithmic:
-				logMin := math.Log(float64(stats.Min))
-				logMax := math.Log(float64(stats.Max))
+				logMin := math.Log(float64(minY))
+				logMax := math.Log(float64(maxY))
 				logScaledTime := numeric.NormalizeToRange(float64(i+1), float64(size.Height-3), 2, logMin, logMax)
 				scaledDuration = math.Pow(math.E, logScaledTime)
 			}
@@ -114,23 +115,37 @@ func computeYAxis(
 	}
 }
 
+// effectiveYBounds is a graph specific view over the stats, normally if min and max are equal
+// that's not a problem, but its an issue for graphs so hence this wrapper layer to avoid NaNs and
+// infs.
+func effectiveYBounds(s *data.Stats) (minY, maxY time.Duration) {
+	// stats are different always return them.
+	if s.Min != s.Max {
+		return s.Min, s.Max
+	}
+	// the same min and max so avoid degenerate divide by zero problems, create fake min-max by
+	// enlarging and shrinking the current value.
+	return s.Min / 2, s.Min * 2
+}
+
 func getY(dur time.Duration, yAxis drawingYAxis, s terminal.Size) int {
 	newMin := max(1, s.Height-2)
 	newMax := min(2, s.Height)
+	minY, maxY := effectiveYBounds(yAxis.stats)
 	switch yAxis.scale {
 	case Linear:
 		return int(numeric.NormalizeToRange(
 			float64(dur),
-			float64(yAxis.stats.Min),
-			float64(yAxis.stats.Max),
+			float64(minY),
+			float64(maxY),
 			float64(newMin),
 			float64(newMax),
 		))
 	case Logarithmic:
 		return int(numeric.NormalizeToRange(
 			math.Log(float64(dur)),
-			math.Log(float64(yAxis.stats.Min)),
-			math.Log(float64(yAxis.stats.Max)),
+			math.Log(float64(minY)),
+			math.Log(float64(maxY)),
 			float64(newMin),
 			float64(newMax),
 		))


### PR DESCRIPTION
If you get unlucky have two initial packets with matching durations (usually only for timeouts - network noise is fun) then the graph package will panic as it cannot compute a y-axis without various places dividing by zero.

This PR fixes that by adding a new `effectiveYBounds` which will generate a fake min and max to ensure no divide by zeros occur when matching durations does happen.